### PR TITLE
feat(api): add Task entity and Flyway V2 tasks table

### DIFF
--- a/src/main/java/org/fanta/taskify/task/Task.java
+++ b/src/main/java/org/fanta/taskify/task/Task.java
@@ -1,0 +1,40 @@
+package org.fanta.taskify.task;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Entity
+@Table(name = "tasks")
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 120)
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TaskStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+}

--- a/src/main/java/org/fanta/taskify/task/TaskRepository.java
+++ b/src/main/java/org/fanta/taskify/task/TaskRepository.java
@@ -1,0 +1,6 @@
+package org.fanta.taskify.task;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/src/main/java/org/fanta/taskify/task/TaskService.java
+++ b/src/main/java/org/fanta/taskify/task/TaskService.java
@@ -1,0 +1,11 @@
+package org.fanta.taskify.task;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TaskService {
+
+    private final TaskRepository repo;
+}

--- a/src/main/java/org/fanta/taskify/task/TaskStatus.java
+++ b/src/main/java/org/fanta/taskify/task/TaskStatus.java
@@ -1,0 +1,7 @@
+package org.fanta.taskify.task;
+
+public enum TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE
+}

--- a/src/main/resources/db/migration/V2__create_task.sql
+++ b/src/main/resources/db/migration/V2__create_task.sql
@@ -1,0 +1,11 @@
+CREATE TABLE tasks (
+    id  BIGSERIAL PRIMARY KEY,
+    title VARCHAR(120) NOT NULL,
+    description TEXT,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_tasks_status ON tasks(status);
+CREATE INDEX idx_tasks_created_at ON tasks(created_at);


### PR DESCRIPTION
Closes #2

What changed
- Added Flyway V2 migration to create `tasks` table
- Added `Task` entity and `TaskStatus` enum
- Added `TaskRepository` and `TaskService` skeleton

How to test
1) docker compose up -d
2) Run the app
3) Verify Flyway applies V2 in logs
4) Optional: docker exec -it taskify-db psql -U taskify -d taskify -c "\dt"