### PR TITLE
Day 10: Add Swagger and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Taskify
+
+Taskify is a simple task management backend built with Spring Boot, PostgreSQL, Flyway, and JPA.
+
+## Tech Stack
+
+- Java 17
+- Spring Boot
+- Spring Data JPA
+- PostgreSQL
+- Flyway
+- Maven
+- Swagger / OpenAPI
+
+## 
+## Features
+
+- Create a task
+- Get all tasks
+- Get a task by ID
+- Update a task
+- Delete a task
+- Request validation
+- Global error handling
+- Database migrations with Flyway
+
+## Run Locally
+
+### 1. Start PostgreSQL
+
+```bash
+docker compose up -d
+```
+
+### 2. Run the application
+
+Use IntelliJ IDEA or run:
+
+```bash
+./mvnw spring-boot:run
+```
+
+### 3. Open Swagger UI
+
+```text
+http://localhost:8080/swagger-ui/index.html
+```
+
+## API Endpoints
+
+- `POST /tasks`
+- `GET /tasks`
+- `GET /tasks/{id}`
+- `PUT /tasks/{id}`
+- `DELETE /tasks/{id}`
+
+## Example Request
+
+```bash
+curl -X POST http://localhost:8080/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Buy milk","description":"2 bottles","status":"TODO"}'
+```

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/fanta/taskify/task/TaskController.java
+++ b/src/main/java/org/fanta/taskify/task/TaskController.java
@@ -1,6 +1,7 @@
 package org.fanta.taskify.task;
 
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,6 +16,7 @@ public class TaskController {
     }
 
     @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
     public Task create(@Valid @RequestBody TaskRequest request) {
         return service.create(request);
     }
@@ -35,6 +37,7 @@ public class TaskController {
     }
 
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
         service.delete(id);
     }


### PR DESCRIPTION
Closes #8 

What changed
- Added Swagger / OpenAPI support
- Improved HTTP status codes for create and delete endpoints
- Added project README with setup instructions and API usage
How to test
1. Run the application
2. Open Swagger UI
3. Verify endpoints are visible and executable
4. Read README and follow local setup instructions